### PR TITLE
Add jshint config

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,5 +1,8 @@
-ruby:
-  config_file: ruby.yml
-
 coffeescript:
   config_file: coffeescript.json
+
+jshint:
+  config_file: .jshintrc
+
+ruby:
+  config_file: ruby.yml

--- a/jshintrc
+++ b/jshintrc
@@ -1,0 +1,33 @@
+{
+  "asi": false,
+  "bitwise": true,
+  "browser": true,
+  "camelcase": true,
+  "curly": true,
+  "forin": true,
+  "immed": true,
+  "latedef": "nofunc",
+  "maxlen": 80,
+  "newcap": true,
+  "noarg": true,
+  "noempty": true,
+  "nonew": true,
+  "predef": [
+    "$",
+    "jQuery",
+
+    "jasmine",
+    "beforeEach",
+    "describe",
+    "expect",
+    "it",
+
+    "angular",
+    "inject",
+    "module"
+  ],
+  "quotmark": true,
+  "trailing": true,
+  "undef": true,
+  "unused": true
+}


### PR DESCRIPTION
In preparation for implementing owner level configuration for the jshint linter.

Once this is merged and the jshint owner level config deployed:
- People who signed up _before_ we configured everyone to use this repo as their owner config will continue to see the same behavior
- People who have signed up _since_ we configured everyone to use this repo as their owner config  _and_ have not configured their own `jshintrc` will see different behavior
